### PR TITLE
Update zstd compression flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,12 @@ RUN cp "microvm-kernel-$(uname -m)-${KERNEL_BRANCH}.config" .config
 FROM linux.git AS vmlinux-arm64
 RUN make Image -j"$(nproc)"
 # hadolint ignore=DL3059
-RUN zstd -9 arch/arm64/boot/Image -o vmlinux.bin.zst
+RUN zstd --compress --no-progress --force --rm -9 arch/arm64/boot/Image -o vmlinux.bin.zst
 
 FROM linux.git AS vmlinux-amd64
 RUN make vmlinux -j"$(nproc)"
 # hadolint ignore=DL3059
-RUN zstd -9 vmlinux -o vmlinux.bin.zst
+RUN zstd --compress --no-progress --force --rm -9 vmlinux -o vmlinux.bin.zst
 
 # hadolint ignore=DL3006
 FROM vmlinux-${TARGETARCH} AS vmlinux


### PR DESCRIPTION
We are still using compression level 9 but we are
suppressing the progress bar and removing source files.

Change-type: patch