### PR TITLE
Discontinue linux510 release tag and mark linux61 as default

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -51,4 +51,4 @@ jobs:
           "linux/arm64": ["self-hosted","ARM64"]
         }  
       docker_images: ghcr.io/product-os/github-runner-kernel
-      bake_targets: linux510,linux61
+      bake_targets: default,linux61

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "KERNEL_BRANCH" {
-  default = "5.10"
+  default = "6.1"
 }
 
 target "default" {


### PR DESCRIPTION
linux510 is no longer used by any platforms internally

Change-type: minor
See: https://balena.fibery.io/Work/Improvement/Build-kernel-6.1-by-default-and-remove-NFS-support-2740