### PR TITLE
Bump kernel base from v6.1 to v6.1.170

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG KERNEL_BRANCH=6.1
+ARG KERNEL_VERSION=6.1.170
 
 RUN git clone --depth 1 -c advice.detachedHead=false \
-    --branch "v${KERNEL_BRANCH}" https://github.com/torvalds/linux.git .
+    --branch "v${KERNEL_VERSION}" https://github.com/gregkh/linux.git .
 
 COPY patches/${KERNEL_BRANCH}/*.patch ./
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 ARCH ?= $(shell uname -m)
 KERNEL_BRANCH ?= 6.1
+KERNEL_VERSION ?= 6.1.170
 MAKEFILE_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
 
 # normalize machine to docker platform
@@ -19,6 +20,7 @@ linux.git:
 	docker build . \
 		--platform $(PLATFORM) \
 		--build-arg KERNEL_BRANCH=$(KERNEL_BRANCH) \
+		--build-arg KERNEL_VERSION=$(KERNEL_VERSION) \
 		--target linux.git \
 		--output type=image,name=$(IMAGE_TAG)
 
@@ -27,6 +29,7 @@ vmlinux:
 	docker build . \
 		--platform $(PLATFORM) \
 		--build-arg KERNEL_BRANCH=$(KERNEL_BRANCH) \
+		--build-arg KERNEL_VERSION=$(KERNEL_VERSION) \
 		--target vmlinux-out \
 		--output type=local,dest=vmlinux
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,10 @@ variable "KERNEL_BRANCH" {
   default = "6.1"
 }
 
+variable "KERNEL_VERSION" {
+  default = "6.1.170"
+}
+
 target "default" {
   platforms = [
     "linux/amd64",
@@ -9,13 +13,15 @@ target "default" {
   ]
   target = "vmlinux-out"
   args = {
-    KERNEL_BRANCH = KERNEL_BRANCH
+    KERNEL_BRANCH  = KERNEL_BRANCH
+    KERNEL_VERSION = KERNEL_VERSION
   }
 }
 
 target "linux61" {
   inherits = ["default"]
   args = {
-    KERNEL_BRANCH = "6.1"
+    KERNEL_BRANCH  = "6.1"
+    KERNEL_VERSION = "6.1.170"
   }
 }


### PR DESCRIPTION
## Summary

- Bump kernel git pin from bare `v6.1` (Dec 2022) to `v6.1.170`, picking up ~170 stable releases worth of accumulated security and bug fixes.
- Introduce a separate `KERNEL_VERSION` arg/variable (defaulting to `6.1.170`) so future stable bumps require a single value change while `KERNEL_BRANCH=6.1` continues to identify the `patches/`/`config/` subdirectories.
- Switch the clone source from `torvalds/linux` to `gregkh/linux` — `torvalds/linux` only carries mainline tags, so it has `v6.1` (which worked by coincidence) but **not** any `v6.1.y` point release. The previous setup was effectively pinned to the `.0` release with no path to picking up stable patches.

## Context — CVE-2026-31431 ("Copy Fail" / `algif_aead`)

This work was kicked off by [CVE-2026-31431](https://copy.fail/), an unprivileged-LPE / container-escape primitive in `crypto/algif_aead.c`. Investigation found:

- **The fix is not yet in any `linux-6.1.y` release.** Mainline fix is `a664bf3d603d` (in 7.0); stable fixes are in `6.18.22` and `6.19.12`. Eric Biggers posted a 9-patch backport for 6.1.y on 2026-04-30 ([lore](https://lore.kernel.org/all/20260430062731.140497-1-ebiggers@kernel.org/)) — it was in stable-review at the time of this PR and expected in `6.1.171+`.
- **This kernel build is unaffected in practice.** Both arch configs already have `# CONFIG_CRYPTO_USER_API_AEAD is not set` (along with the rest of `CONFIG_CRYPTO_USER_API_*` and `CONFIG_CRYPTO_AUTHENC`), so the entire AF_ALG userspace surface is unbuilt — there is no `algif_aead` module/built-in in the produced `vmlinux`.

## Verification

- [x] `git ls-remote` confirms `v6.1.170` resolves to `02d4d51a937120cc924e3df214b1ff271234f020` on `gregkh/linux` (and the canonical kernel.org `stable/linux.git`).
- [x] Existing `patches/6.1/0001-UBUNTU-SAUCE-...` and `0002-HACK-...` patches still apply cleanly to `kernel/sys.c` at `v6.1.170` (verified via `git apply --check` against a temp checkout).
